### PR TITLE
Override ToString for better debugging experience

### DIFF
--- a/Webshop.Entities/Product.cs
+++ b/Webshop.Entities/Product.cs
@@ -13,5 +13,7 @@ namespace Webshop.Entities
         public string Description { get; set; }
         public int Stock { get; set; }
         public string SKU { get; set; }
+
+        public override string ToString() => $"{Name}, €{Price} ({Id})";
     }
 }


### PR DESCRIPTION
De default ToString() is .GetType().FullName
vb: Webshop.Entities.Product

Door de ToString() te overriden wijzig je dat naar wat je wil

Het voordeel:
Tijdens debuggen kun je over een variabele hoveren en wordt die ToString() getoond.
Op die manier kun je diretc zien over welke entiteit het precies gaat.
Ik vind dit een groot gemak tijdens debuggen applicatie / bug tracking / debugging unit tests
Maar dat is niet verplicht ofzo... Het is iets dat je al dan niet doet.